### PR TITLE
Added FAQ and resource markdown files to be read by portal.

### DIFF
--- a/meta/bounty-faq.md
+++ b/meta/bounty-faq.md
@@ -1,0 +1,41 @@
+# Bounty FAQ
+
+### I'm interested in working on a bounty, what do I do?
+
+If you're not already a member, please join the [GMC Discord Server](https://discord.gg/tZDFBbh7uM). There is a public [Bounties Discord Channel](https://discord.com/channels/1109303903767507016/1174420540220506132) in that server. Send a brief message in that channel indicating which bounty you're interested in, and someone from the GMC will respond. 
+
+It's important to let the GMC know that you're planning to work on a given bounty. They can let you know if anyone else is already working on it.
+
+### I've completed a bounty, how do I submit a claim?
+
+If you're not already a member, please join the [GMC Discord Server](https://discord.gg/tZDFBbh7uM). There is a public [Bounties Discord Channel](https://discord.com/channels/1109303903767507016/1174420540220506132) in that server. Send a brief message in that channel indicating which bounty you're claming, and someone from the GMC will respond. 
+
+Alternatively, you can DM the GMC Administrator (currently ShfRyn.) Or leave a message in the [GMC Public Discussion thread](https://discord.com/channels/405159462932971535/1064611985523757067) on the official [Rocket Pool discord server](https://discord.gg/rocketpool).
+
+### I've successfully claimed a bounty, how and when will I be paid?
+
+Bounty payouts take place via a manual process managed by the GMC. A member of the GMC will be in touch to ask you for the address to which payments should be sent. Payments are distributed on mainnet ethereum in either RPL or LUSD.
+
+### Where can I ask more questions about a bounty?
+Either one of the aforementioned communication channels:
+* [Bounties Discord Channel](https://discord.com/channels/1109303903767507016/1174420540220506132)
+* [GMC Public Discussion Thread](https://discord.com/channels/405159462932971535/1064611985523757067)
+* DM the GMC Administrator (currently ShfRyn.)
+
+Alternatively, you can get in touch with one of the listed contacts for the bounty you are interested in. 
+
+### When are new bounties added?
+New bounties are approved in a monthly process managed by the GMC, so at best once a month. Bounties are proposed by members of the Rocket Pool DAO. There is no guarantee there will be new bounties approved in a given month.
+
+### What is the GMC?
+The GMC is the Rocket Pool Grants Management Committee. This is an elected committee made up of members of the Rocket Pool DAO. Members are elected for 12 month terms by the Rocket Pool pDAO, which is made up of Rocket Pool node operators. 
+
+### Do bounties expire?
+
+Most bounties do not expire, but there are exceptions. Make sure to check on the bounties details pages, if the bounty expires, it will be clearly noted.
+
+Expired bounties should be marked with the 'closed' status at the point of expiry, but this is a manual process, and the GMC does not directly control bounty frontends, so please double-check with the GMC via the communication channels listed above.
+
+### Does the bounty payout stay the same?
+
+The bounty amount is recalculated in RPL every quarter. If the bounty was awarded during a previous quarter than the claim, the RPL amount is recalculated at the time of payment creation.

--- a/meta/resources.md
+++ b/meta/resources.md
@@ -1,0 +1,14 @@
+# Bounty Resources
+
+### GMC Discord
+* [Server](https://discord.gg/tZDFBbh7uM)
+* [Bounties Channel](https://discord.com/channels/1109303903767507016/1174420540220506132)
+
+### Offical Rocket Pool Discord
+* [Server](https://discord.gg/rocketpool)
+* [GMC Public Discussion thread](https://discord.com/channels/405159462932971535/1064611985523757067)
+
+### Documentation
+* [GMC Membership Record](https://rpips.rocketpool.net/RPIPs/RPIP-36#grants-management-committee)
+* [GMC Tracking Sheet](https://docs.google.com/spreadsheets/d/1oxOioCXoVIqY4aFS9mEgHMgK18QLEfJcwlZk2-l6cfc/edit#gid=0)
+* [GMC Records](https://rpips.rocketpool.net/RPIPs/RPIP-29)


### PR DESCRIPTION
Will be used on portal: <https://longforwisdom.github.io/rp-bounty/>.

Couple of reasons these should live in the GMC repo:
1. It means you can all update them to include whatever people end up asking you.
2. If anyone forks the bounty portal, the various frontends don't need to keep FAQs in sync.
3. If anyone wants to use the resources on a related site, they can. 